### PR TITLE
fixed attribute error which was occuring when the game 🎮 was won

### DIFF
--- a/game.py
+++ b/game.py
@@ -87,15 +87,18 @@ while running:
                         pygame.quit()
                         pygame.mixer.music.stop()
                         quit()
-                    # check if the event in R key
-                    if event.key == pygame.K_r:
-                        # Restart the game
-                        game_state = "playing"
-                        score = 0
-                        # Add your code to reset the game here
-                        break
-                    if event.key == pygame.K_q:
-                        quit()
+                        
+                    #  Making sure we only try to access the 'key' attribute for keyboard events, avoiding the 'AttributeError' that was occurring previously when moving the mouse over after winning the game.    
+                    if event.type == pygame.KEYDOWN:                 
+                    # check if the event in R key 
+                        if event.key == pygame.K_r:
+                            # Restart the game
+                            game_state = "playing"
+                            score = 0
+                            # Add your code to reset the game here
+                            break
+                        if event.key == pygame.K_q:
+                            quit()
                 else:
                     continue
                 break


### PR DESCRIPTION
Previously, this error was being thrown when moving the mouse over the scene below, and subsequently causing the app to crush.

```

if event.key == pygame.K_r:
AttributeError: 'pygame.event.Event' object has no attribute 'key'

```
![attribute error fixed ](https://user-images.githubusercontent.com/48782826/229364456-cd69e0a5-ecd4-4b88-971b-1867179fbe66.png)

The following changes has been made:

```diff python

+ if event.type == pygame.KEYDOWN:                 
         # check if the event in R key 
            if event.key == pygame.K_r:
                 # Restart the game
                    game_state = "playing"
                    score = 0
                  # Add your code to reset the game here
                    break
           if event.key == pygame.K_q:
                    quit()

```

This ensures that we only try to access the 'key' attribute for keyboard events, avoiding the 'AttributeError' which was being triggered by the mouse event.